### PR TITLE
Internalize helpers and replace YAML with JSON serialization

### DIFF
--- a/src/Bonsai.ML.LinearDynamicalSystems/Bonsai.ML.LinearDynamicalSystems.csproj
+++ b/src/Bonsai.ML.LinearDynamicalSystems/Bonsai.ML.LinearDynamicalSystems.csproj
@@ -10,7 +10,6 @@
     <PackageReference Include="Bonsai.Core" Version="2.8.1" />
     <PackageReference Include="Bonsai.Scripting.Python" Version="0.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="YamlDotNet" Version="13.7.1" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="*.py" />

--- a/src/Bonsai.ML.LinearDynamicalSystems/Kinematics/KFModelParameters.cs
+++ b/src/Bonsai.ML.LinearDynamicalSystems/Kinematics/KFModelParameters.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using YamlDotNet.Serialization;
 using System;
 using System.Reactive.Linq;
@@ -284,17 +284,17 @@ namespace Bonsai.ML.LinearDynamicalSystems.Kinematics
         {
     		return Observable.Select(source, pyObject =>
     		{
-                var pos_x0PyObj = PythonHelper.GetPythonAttribute<double>(pyObject, "pos_x0");
-                var pos_y0PyObj = PythonHelper.GetPythonAttribute<double>(pyObject, "pos_y0");
-                var vel_x0PyObj = PythonHelper.GetPythonAttribute<double>(pyObject, "vel_x0");
-                var vel_y0PyObj = PythonHelper.GetPythonAttribute<double>(pyObject, "vel_y0");
-                var acc_x0PyObj = PythonHelper.GetPythonAttribute<double>(pyObject, "acc_x0");
-                var acc_y0PyObj = PythonHelper.GetPythonAttribute<double>(pyObject, "acc_y0");
-                var sigma_aPyObj = PythonHelper.GetPythonAttribute<double>(pyObject, "sigma_a");
-                var sigma_xPyObj = PythonHelper.GetPythonAttribute<double>(pyObject, "sigma_x");
-                var sigma_yPyObj = PythonHelper.GetPythonAttribute<double>(pyObject, "sigma_y");
-                var sqrt_diag_V0_valuePyObj = PythonHelper.GetPythonAttribute<double>(pyObject, "sqrt_diag_V0_value");
-                var fpsPyObj = PythonHelper.GetPythonAttribute<int>(pyObject, "fps");
+                var pos_x0PyObj = pyObject.GetAttr<double>("pos_x0");
+                var pos_y0PyObj = pyObject.GetAttr<double>("pos_y0");
+                var vel_x0PyObj = pyObject.GetAttr<double>("vel_x0");
+                var vel_y0PyObj = pyObject.GetAttr<double>("vel_y0");
+                var acc_x0PyObj = pyObject.GetAttr<double>("acc_x0");
+                var acc_y0PyObj = pyObject.GetAttr<double>("acc_y0");
+                var sigma_aPyObj = pyObject.GetAttr<double>("sigma_a");
+                var sigma_xPyObj = pyObject.GetAttr<double>("sigma_x");
+                var sigma_yPyObj = pyObject.GetAttr<double>("sigma_y");
+                var sqrt_diag_V0_valuePyObj = pyObject.GetAttr<double>("sqrt_diag_V0_value");
+                var fpsPyObj = pyObject.GetAttr<int>("fps");
 
                 return new KFModelParameters {
                     Pos_x0 = pos_x0PyObj,

--- a/src/Bonsai.ML.LinearDynamicalSystems/Kinematics/KFModelParameters.cs
+++ b/src/Bonsai.ML.LinearDynamicalSystems/Kinematics/KFModelParameters.cs
@@ -3,7 +3,6 @@ using YamlDotNet.Serialization;
 using System;
 using System.Reactive.Linq;
 using Python.Runtime;
-using Bonsai.ML.LinearDynamicalSystems.Python;
 
 namespace Bonsai.ML.LinearDynamicalSystems.Kinematics
 {

--- a/src/Bonsai.ML.LinearDynamicalSystems/Kinematics/KFModelParameters.cs
+++ b/src/Bonsai.ML.LinearDynamicalSystems/Kinematics/KFModelParameters.cs
@@ -1,8 +1,8 @@
 ﻿using System.ComponentModel;
-using YamlDotNet.Serialization;
 using System;
 using System.Reactive.Linq;
 using Python.Runtime;
+using Newtonsoft.Json;
 
 namespace Bonsai.ML.LinearDynamicalSystems.Kinematics
 {
@@ -52,7 +52,7 @@ namespace Bonsai.ML.LinearDynamicalSystems.Kinematics
         /// <summary>
         /// x position at time 0
         /// </summary>
-        [YamlMember(Alias="pos_x0")]
+        [JsonProperty("pos_x0")]
         [Description("x position at time 0")]
         public double Pos_x0
         {
@@ -70,7 +70,7 @@ namespace Bonsai.ML.LinearDynamicalSystems.Kinematics
         /// <summary>
         /// y position at time 0
         /// </summary>
-        [YamlMember(Alias="pos_y0")]
+        [JsonProperty("pos_y0")]
         [Description("y position at time 0")]
         public double Pos_y0
         {
@@ -88,7 +88,7 @@ namespace Bonsai.ML.LinearDynamicalSystems.Kinematics
         /// <summary>
         /// x velocity at time 0
         /// </summary>
-        [YamlMember(Alias="vel_x0")]
+        [JsonProperty("vel_x0")]
         [Description("x velocity at time 0")]
         public double Vel_x0
         {
@@ -106,7 +106,7 @@ namespace Bonsai.ML.LinearDynamicalSystems.Kinematics
         /// <summary>
         /// y velocity at time 0
         /// </summary>
-        [YamlMember(Alias="vel_y0")]
+        [JsonProperty("vel_y0")]
         [Description("y velocity at time 0")]
         public double Vel_y0
         {
@@ -124,7 +124,7 @@ namespace Bonsai.ML.LinearDynamicalSystems.Kinematics
         /// <summary>
         /// x acceleration at time 0
         /// </summary>
-        [YamlMember(Alias="acc_x0")]
+        [JsonProperty("acc_x0")]
         [Description("x acceleration at time 0")]
         public double Acc_x0
         {
@@ -142,7 +142,7 @@ namespace Bonsai.ML.LinearDynamicalSystems.Kinematics
         /// <summary>
         /// x velocity at time 0
         /// </summary>
-        [YamlMember(Alias="acc_y0")]
+        [JsonProperty("acc_y0")]
         [Description("x velocity at time 0")]
         public double Acc_y0
         {
@@ -160,7 +160,7 @@ namespace Bonsai.ML.LinearDynamicalSystems.Kinematics
         /// <summary>
         /// covariance of a
         /// </summary>
-        [YamlMember(Alias="sigma_a")]
+        [JsonProperty("sigma_a")]
         [Description("covariance of a")]
         public double Sigma_a
         {
@@ -178,7 +178,7 @@ namespace Bonsai.ML.LinearDynamicalSystems.Kinematics
         /// <summary>
         /// covariance of x
         /// </summary>
-        [YamlMember(Alias="sigma_x")]
+        [JsonProperty("sigma_x")]
         [Description("covariance of x")]
         public double Sigma_x
         {
@@ -196,7 +196,7 @@ namespace Bonsai.ML.LinearDynamicalSystems.Kinematics
         /// <summary>
         /// covariance of y
         /// </summary>
-        [YamlMember(Alias="sigma_y")]
+        [JsonProperty("sigma_y")]
         [Description("covariance of y")]
         public double Sigma_y
         {
@@ -214,7 +214,7 @@ namespace Bonsai.ML.LinearDynamicalSystems.Kinematics
         /// <summary>
         /// v0
         /// </summary>
-        [YamlMember(Alias="sqrt_diag_V0_value")]
+        [JsonProperty("sqrt_diag_V0_value")]
         [Description("v0")]
         public double Sqrt_diag_V0_value
         {
@@ -232,7 +232,7 @@ namespace Bonsai.ML.LinearDynamicalSystems.Kinematics
         /// <summary>
         /// frames per second
         /// </summary>
-        [YamlMember(Alias="fps")]
+        [JsonProperty("fps")]
         [Description("frames per second")]
         public int Fps
         {

--- a/src/Bonsai.ML.LinearDynamicalSystems/Kinematics/KinematicComponent.cs
+++ b/src/Bonsai.ML.LinearDynamicalSystems/Kinematics/KinematicComponent.cs
@@ -1,6 +1,6 @@
-using System.ComponentModel;
-using YamlDotNet.Serialization;
+﻿using System.ComponentModel;
 using System.Xml.Serialization;
+using Newtonsoft.Json;
 
 namespace Bonsai.ML.LinearDynamicalSystems.Kinematics
 {
@@ -20,7 +20,7 @@ namespace Bonsai.ML.LinearDynamicalSystems.Kinematics
         /// x state component
         /// </summary>
         [XmlIgnore()]
-        [YamlMember(Alias="x_state_component")]
+        [JsonProperty("x_state_component")]
         [Description("X state component")]
         public StateComponent X
         {
@@ -38,7 +38,7 @@ namespace Bonsai.ML.LinearDynamicalSystems.Kinematics
         /// y state component
         /// </summary>
         [XmlIgnore()]
-        [YamlMember(Alias="y_state_component")]
+        [JsonProperty("y_state_component")]
         [Description("Y state component")]
         public StateComponent Y
         {
@@ -56,7 +56,7 @@ namespace Bonsai.ML.LinearDynamicalSystems.Kinematics
         /// covariance between state components
         /// </summary>
         [XmlIgnore()]
-        [YamlMember(Alias="covariance")]
+        [JsonProperty("covariance")]
         [Description("covariance between state components")]
         public double Covariance
         {

--- a/src/Bonsai.ML.LinearDynamicalSystems/Kinematics/KinematicState.cs
+++ b/src/Bonsai.ML.LinearDynamicalSystems/Kinematics/KinematicState.cs
@@ -1,8 +1,8 @@
-using System.ComponentModel;
-using YamlDotNet.Serialization;
+﻿using System.ComponentModel;
 using System;
 using System.Reactive.Linq;
 using System.Xml.Serialization;
+using Newtonsoft.Json;
 
 namespace Bonsai.ML.LinearDynamicalSystems.Kinematics
 {
@@ -24,7 +24,7 @@ namespace Bonsai.ML.LinearDynamicalSystems.Kinematics
         /// position kinematic component
         /// </summary>
         [XmlIgnore()]
-        [YamlMember(Alias="position")]
+        [JsonProperty("position")]
         [Description("position kinematic component")]
         public KinematicComponent Position
         {
@@ -42,7 +42,7 @@ namespace Bonsai.ML.LinearDynamicalSystems.Kinematics
         /// velocity kinematic components
         /// </summary>
         [XmlIgnore()]
-        [YamlMember(Alias="velocity")]
+        [JsonProperty("velocity")]
         [Description("velocity kinematic components")]
         public KinematicComponent Velocity
         {
@@ -60,7 +60,7 @@ namespace Bonsai.ML.LinearDynamicalSystems.Kinematics
         /// acceleration kinematic components
         /// </summary>
         [XmlIgnore()]
-        [YamlMember(Alias="acceleration")]
+        [JsonProperty("acceleration")]
         [Description("acceleration kinematic components")]
         public KinematicComponent Acceleration
         {

--- a/src/Bonsai.ML.LinearDynamicalSystems/Kinematics/Observation2D.cs
+++ b/src/Bonsai.ML.LinearDynamicalSystems/Kinematics/Observation2D.cs
@@ -1,8 +1,7 @@
-using System.ComponentModel;
-using YamlDotNet.Serialization;
+﻿using System.ComponentModel;
 using System;
 using System.Reactive.Linq;
-using Python.Runtime;
+using Newtonsoft.Json;
 
 namespace Bonsai.ML.LinearDynamicalSystems.Kinematics
 {
@@ -25,7 +24,7 @@ namespace Bonsai.ML.LinearDynamicalSystems.Kinematics
         /// <summary>
         /// x coordinate
         /// </summary>
-        [YamlMember(Alias="x")]
+        [JsonProperty("x")]
         [Description("x coordinate")]
         public double X
         {
@@ -43,7 +42,7 @@ namespace Bonsai.ML.LinearDynamicalSystems.Kinematics
         /// <summary>
         /// y coordinate
         /// </summary>
-        [YamlMember(Alias="y")]
+        [JsonProperty("y")]
         [Description("y coordinate")]
         public double Y
         {

--- a/src/Bonsai.ML.LinearDynamicalSystems/NumpyHelper.cs
+++ b/src/Bonsai.ML.LinearDynamicalSystems/NumpyHelper.cs
@@ -92,11 +92,12 @@ namespace Bonsai.ML.LinearDynamicalSystems
 
         private static PyObject deepcopy;
 
-        private static readonly Lazy<PyObject> np = new Lazy<PyObject>(InitializeNumpy);
+        private static readonly Lazy<PyObject> np = new(InitializeNumpy);
 
-        private static readonly Dictionary<Type, PyObject> np_dtypes = new Dictionary<Type, PyObject>();
+        private static readonly Dictionary<Type, PyObject> np_dtypes = new();
 
-        private static readonly Dictionary<string, Type> csharp_dtypes = new Dictionary<string, Type>(){
+        private static readonly Dictionary<string, Type> csharp_dtypes = new()
+        {
             { "uint8",      typeof(byte)    },
             { "uint16",     typeof(ushort)  },
             { "uint32",     typeof(uint)    },

--- a/src/Bonsai.ML.LinearDynamicalSystems/NumpyHelper.cs
+++ b/src/Bonsai.ML.LinearDynamicalSystems/NumpyHelper.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Python.Runtime;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -8,9 +8,9 @@ using System.Text;
 using System.Linq;
 using System.Runtime.InteropServices;
 
-namespace Bonsai.ML.LinearDynamicalSystems.Python
+namespace Bonsai.ML.LinearDynamicalSystems
 {
-    public class NumpyHelper
+    internal class NumpyHelper
     {
         public class NumpyArrayInterface
         {
@@ -26,7 +26,7 @@ namespace Bonsai.ML.LinearDynamicalSystems.Python
 
                 var typestr = meta["typestr"].As<string>();
                 var dtype = typestr.Substring(1);
-                switch(dtype)
+                switch (dtype)
                 {
                     case "b1":
                         DataType = typeof(bool);
@@ -60,7 +60,7 @@ namespace Bonsai.ML.LinearDynamicalSystems.Python
                         break;
                     default:
                         throw new Exception($"Type '{dtype}' not supported");
-                } 
+                }
                 Shape = obj.GetAttr("shape").As<long[]>();
                 NBytes = obj.GetAttr("nbytes").As<int>();
             }
@@ -81,11 +81,11 @@ namespace Bonsai.ML.LinearDynamicalSystems.Python
             var info = new NumpyArrayInterface(array);
 
             PyObject arr = array;
-            if(!info.IsCStyleContiguous)
+            if (!info.IsCStyleContiguous)
             {
                 arr = deepcopy.Invoke(array);
             }
-           
+
             byte[] data = new byte[info.NBytes];
             Marshal.Copy(info.Address, data, 0, info.NBytes);
             if (info.DataType == typeof(byte) && info.Shape.Length == 1)
@@ -150,7 +150,7 @@ namespace Bonsai.ML.LinearDynamicalSystems.Python
         {
             PyObject dtype;
             np_dtypes.TryGetValue(type, out dtype);
-            if(dtype == null)
+            if (dtype == null)
             {
                 throw new Exception($"type '{type}' not supported.");
             }
@@ -161,7 +161,7 @@ namespace Bonsai.ML.LinearDynamicalSystems.Python
         {
             Type type;
             csharp_dtypes.TryGetValue(str, out type);
-            if(type == null)
+            if (type == null)
             {
                 throw new Exception($"type '{type}' not supported.");
             }
@@ -174,7 +174,7 @@ namespace Bonsai.ML.LinearDynamicalSystems.Python
             {
                 return true;
             }
-            
+
             public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
             {
                 var dtypes = new List<string>
@@ -223,7 +223,7 @@ namespace Bonsai.ML.LinearDynamicalSystems.Python
                 }
                 else
                 {
-                    object value =  array.GetValue(indices);
+                    object value = array.GetValue(indices);
                     sb.Append(value.ToString());
                 }
             }
@@ -285,14 +285,14 @@ namespace Bonsai.ML.LinearDynamicalSystems.Python
                     dimensions.Add(currentArray.Count);
                     if (currentArray.Count > 0)
                     {
-                        if ((currentArray.Any(item => !(item is JArray)) && currentArray.Any(item => item is JArray)) || (currentArray.All(item => item is JArray) && currentArray.Any(item => ((JArray)item).Count != ((JArray)currentArray.First()).Count)))
+                        if (currentArray.Any(item => !(item is JArray)) && currentArray.Any(item => item is JArray) || currentArray.All(item => item is JArray) && currentArray.Any(item => ((JArray)item).Count != ((JArray)currentArray.First()).Count))
                         {
                             throw new Exception("Error parsing input string.");
                         }
 
                         if (!(currentArray.First() is JArray) && !currentArray.All(item => double.TryParse(item.ToString(), out _)))
                         {
-                            throw new Exception("Error parsing non numeric types.");                        
+                            throw new Exception("Error parsing non numeric types.");
                         }
                     }
 

--- a/src/Bonsai.ML.LinearDynamicalSystems/NumpyHelper.cs
+++ b/src/Bonsai.ML.LinearDynamicalSystems/NumpyHelper.cs
@@ -79,13 +79,6 @@ namespace Bonsai.ML.LinearDynamicalSystems
         public static Array PyObjectToArray(PyObject array)
         {
             var info = new NumpyArrayInterface(array);
-
-            PyObject arr = array;
-            if (!info.IsCStyleContiguous)
-            {
-                arr = deepcopy.Invoke(array);
-            }
-
             byte[] data = new byte[info.NBytes];
             Marshal.Copy(info.Address, data, 0, info.NBytes);
             if (info.DataType == typeof(byte) && info.Shape.Length == 1)

--- a/src/Bonsai.ML.LinearDynamicalSystems/PythonHelper.cs
+++ b/src/Bonsai.ML.LinearDynamicalSystems/PythonHelper.cs
@@ -6,23 +6,19 @@ namespace Bonsai.ML.LinearDynamicalSystems
 {
     static class PythonHelper
     {
-        public static object GetPythonAttribute(PyObject pyObject, string attributeName)
+        public static object GetArrayAttribute(this PyObject pyObject, string attributeName)
         {
-            using (var attr = pyObject.GetAttr(attributeName))
-            {
-                return ConvertPythonObjectToCSharp(attr);
-            }
+            using var attr = pyObject.GetAttr(attributeName);
+            return ConvertPythonObjectToCSharp(attr);
         }
 
-        public static T GetPythonAttribute<T>(PyObject pyObject, string attributeName)
+        public static T GetAttr<T>(this PyObject pyObject, string attributeName)
         {
-            using (var attr = pyObject.GetAttr(attributeName))
-            {
-                return (T)attr.AsManagedObject(typeof(T));
-            }
+            using var attr = pyObject.GetAttr(attributeName);
+            return attr.As<T>();
         }
 
-        public static object ConvertPythonObjectToCSharp(PyObject pyObject)
+        static object ConvertPythonObjectToCSharp(PyObject pyObject)
         {
             if (PyInt.IsIntType(pyObject))
             {

--- a/src/Bonsai.ML.LinearDynamicalSystems/PythonHelper.cs
+++ b/src/Bonsai.ML.LinearDynamicalSystems/PythonHelper.cs
@@ -1,10 +1,10 @@
-using Python.Runtime;
+﻿using Python.Runtime;
 using System;
 using System.Collections.Generic;
 
-namespace Bonsai.ML.LinearDynamicalSystems.Python
+namespace Bonsai.ML.LinearDynamicalSystems
 {
-    public class PythonHelper
+    static class PythonHelper
     {
         public static object GetPythonAttribute(PyObject pyObject, string attributeName)
         {
@@ -60,8 +60,6 @@ namespace Bonsai.ML.LinearDynamicalSystems.Python
                 return resultDict;
             }
 
-            NumpyHelper numpyHelper = NumpyHelper.Instance;
-            
             if (NumpyHelper.IsNumPyArray(pyObject))
             {
                 return NumpyHelper.PyObjectToArray(pyObject);

--- a/src/Bonsai.ML.LinearDynamicalSystems/SerializeToJson.cs
+++ b/src/Bonsai.ML.LinearDynamicalSystems/SerializeToJson.cs
@@ -1,25 +1,21 @@
-using System;
+﻿using System;
 using System.ComponentModel;
 using System.Reactive.Linq;
-using YamlDotNet.Serialization;
+using Newtonsoft.Json;
 
 namespace Bonsai.ML.LinearDynamicalSystems
 {
     /// <summary>
-    /// Serializes a sequence of data model objects into YAML strings.
+    /// Serializes a sequence of data model objects into JSON strings.
     /// </summary>
     [Combinator()]
     [WorkflowElementCategory(ElementCategory.Transform)]
-    [Description("Serializes a sequence of data model objects into YAML strings.")]
-    public class SerializeToYaml
+    [Description("Serializes a sequence of data model objects into JSON strings.")]
+    public class SerializeToJson
     {
         private IObservable<string> Process<T>(IObservable<T> source)
         {
-            return Observable.Defer(() =>
-            {
-                var serializer = new SerializerBuilder().Build();
-                return Observable.Select(source, value => serializer.Serialize(value)); 
-            });
+            return source.Select(value => JsonConvert.SerializeObject(value));
         }
 
         public IObservable<string> Process(IObservable<Kinematics.KFModelParameters> source)

--- a/src/Bonsai.ML.LinearDynamicalSystems/State.cs
+++ b/src/Bonsai.ML.LinearDynamicalSystems/State.cs
@@ -4,7 +4,6 @@ using System;
 using System.Reactive.Linq;
 using Python.Runtime;
 using System.Xml.Serialization;
-using Bonsai.ML.LinearDynamicalSystems.Python;
 
 namespace Bonsai.ML.LinearDynamicalSystems
 {

--- a/src/Bonsai.ML.LinearDynamicalSystems/State.cs
+++ b/src/Bonsai.ML.LinearDynamicalSystems/State.cs
@@ -1,9 +1,9 @@
 ﻿using System.ComponentModel;
-using YamlDotNet.Serialization;
 using System;
 using System.Reactive.Linq;
 using Python.Runtime;
 using System.Xml.Serialization;
+using Newtonsoft.Json;
 
 namespace Bonsai.ML.LinearDynamicalSystems
 {
@@ -26,7 +26,7 @@ namespace Bonsai.ML.LinearDynamicalSystems
         /// Mean vector - n x 1 dimensional matrix where n is number of features
         /// </summary>
         [XmlIgnore()]
-        [YamlMember(Alias="x")]
+        [JsonProperty("x")]
         [Description("Mean vector")]
         public double[,] X
         {
@@ -44,7 +44,7 @@ namespace Bonsai.ML.LinearDynamicalSystems
         /// Covariance matrix - n x n dimensional matrix where n is number of features
         /// </summary>
         [XmlIgnore()]
-        [YamlMember(Alias="P")]
+        [JsonProperty("P")]
         [Description("Covariance matrix")]
         public double[,] P
         {

--- a/src/Bonsai.ML.LinearDynamicalSystems/State.cs
+++ b/src/Bonsai.ML.LinearDynamicalSystems/State.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using YamlDotNet.Serialization;
 using System;
 using System.Reactive.Linq;
@@ -65,8 +65,8 @@ namespace Bonsai.ML.LinearDynamicalSystems
         {
             return Observable.Select(source, pyObject =>
             {
-                var xPyObj = (double[,])PythonHelper.GetPythonAttribute(pyObject, "x");
-                var PPyObj = (double[,])PythonHelper.GetPythonAttribute(pyObject, "P");
+                var xPyObj = (double[,])pyObject.GetArrayAttribute("x");
+                var PPyObj = (double[,])pyObject.GetArrayAttribute("P");
 
                 return new State {
                     X = xPyObj,

--- a/src/Bonsai.ML.LinearDynamicalSystems/StateComponent.cs
+++ b/src/Bonsai.ML.LinearDynamicalSystems/StateComponent.cs
@@ -1,7 +1,7 @@
-using System.ComponentModel;
-using YamlDotNet.Serialization;
+﻿using System.ComponentModel;
 using System;
 using System.Xml.Serialization;
+using Newtonsoft.Json;
 
 namespace Bonsai.ML.LinearDynamicalSystems
 {
@@ -20,7 +20,7 @@ namespace Bonsai.ML.LinearDynamicalSystems
         /// mean
         /// </summary>
         [XmlIgnore()]
-        [YamlMember(Alias="mean")]
+        [JsonProperty("mean")]
         [Description("mean")]
         public double Mean
         {
@@ -38,7 +38,7 @@ namespace Bonsai.ML.LinearDynamicalSystems
         /// variance
         /// </summary>
         [XmlIgnore()]
-        [YamlMember(Alias="variance")]
+        [JsonProperty("variance")]
         [Description("variance")]
         public double Variance
         {


### PR DESCRIPTION
This PR internalizes all helper classes and attempts to implement conversion functions as static extension methods. It also replaces YAML with JSON serialization to resolve a compatibility issue with rectangular arrays and YAML serialization.